### PR TITLE
Release Python's Global Interpreter Lock

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -20,6 +20,41 @@ export const SYMBOLS = {
     returns: FFIType.void,
   },
 
+  // Used BEFORE calling into Python (from JS)
+  // See: https://docs.python.org/3/c-api/init.html#non-python-created-threads
+  PyGILState_Ensure: {
+    args: [],
+    returns: FFIType.pointer,
+  },
+
+  // Used AFTER calling into Python (from JS)
+  // See: https://docs.python.org/3/c-api/init.html#non-python-created-threads
+  PyGILState_Release: {
+    args: [FFIType.pointer],
+    returns: FFIType.void,
+  },
+
+  // Check if the current thread is holding the GIL
+  // See: https://docs.python.org/3/c-api/init.html#c.PyGILState_Check
+  PyGILState_Check: {
+    args: [],
+    returns: INT,
+  },
+
+  // Used BEFORE calling from Python (into JSCallback)
+  // See: https://docs.python.org/3/c-api/init.html#releasing-the-gil-from-extension-code
+  PyEval_SaveThread: {
+    args: [],
+    returns: FFIType.pointer,
+  },
+
+  // Used AFTER calling from Python (into JSCallback)
+  // See: https://docs.python.org/3/c-api/init.html#releasing-the-gil-from-extension-code
+  PyEval_RestoreThread: {
+    args: [FFIType.pointer],
+    returns: FFIType.void,
+  },
+
   Py_IncRef: {
     args: [FFIType.pointer],
     returns: FFIType.void,


### PR DESCRIPTION
Release Python's Global Interpreter Lock (GIL) when calling into JS Callbacks from Python.

Also release the GIL after each call into Python from JS, to allow python `threading` and `multiprocessing` library to function properly. See Python docs on [Thread State and the Global Interpreter Lock](https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock).

This is also a prerequisite for reliable python3 `asyncio` support coming in future to `bun_python`.